### PR TITLE
Fix: Update types to match native code

### DIFF
--- a/ios/VisionCameraBarcodesScanner.swift
+++ b/ios/VisionCameraBarcodesScanner.swift
@@ -111,7 +111,7 @@ public class VisionCameraBarcodesScanner: FrameProcessorPlugin {
                           let url = barcode.url!.url
                           objData["url"] = url
                       default:
-                          print("value case")
+                          break
 
                       }
                   data.append(objData)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import type {
   Frame,
   CameraTypes,
   ForwardedRef,
-  Barcode,
+  BarcodeData,
   BarcodeScannerPlugin,
   ScanBarcodeOptions,
 } from './types';
@@ -23,7 +23,7 @@ export const Camera = forwardRef(function Camera(
   // @ts-ignore
   const { scanBarcodes } = useBarcodeScanner(options);
   const useWorklets = useRunOnJS(
-    (data: Barcode): void => {
+    (data: BarcodeData): void => {
       callback(data);
     },
     [options]
@@ -31,7 +31,7 @@ export const Camera = forwardRef(function Camera(
   const frameProcessor: ReadonlyFrameProcessor = useFrameProcessor(
     (frame: Frame) => {
       'worklet';
-      const data: Barcode = scanBarcodes(frame);
+      const data: BarcodeData = scanBarcodes(frame);
       // @ts-ignore
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useWorklets(data);

--- a/src/scanBarcodes.ts
+++ b/src/scanBarcodes.ts
@@ -6,7 +6,7 @@ import type {
   Frame,
   ScanBarcodeOptions,
   BarcodeScannerPlugin,
-  Barcode,
+  BarcodeData,
 } from './types';
 import { Platform } from 'react-native';
 
@@ -27,9 +27,9 @@ export function createBarcodeScannerPlugin(
     throw new Error(LINKING_ERROR);
   }
   return {
-    scanBarcodes: (frame: Frame): Barcode => {
+    scanBarcodes: (frame: Frame): BarcodeData => {
       'worklet';
-      return plugin.call(frame) as unknown as Barcode;
+      return plugin.call(frame) as unknown as BarcodeData;
     },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export type Barcode = {
   right: number;
   top: number;
   width: number;
+  displayValue: string;
 };
 
 export type BarcodeData = {
@@ -46,5 +47,5 @@ export type CameraTypes = {
 } & CameraProps;
 
 export type BarcodeScannerPlugin = {
-  scanBarcodes: (frame: Frame) => Barcode;
+  scanBarcodes: (frame: Frame) => BarcodeData;
 };


### PR DESCRIPTION
The native code returns an array of all the barcodes seen in a scan, but the TypeScript code was typed as if only a single barcode was being returned. This updates the TypeScript code to match the native code (and removes a debug print statement in the Swift code). This includes adding the missing displayValue property to the Barcode type.