### PR TITLE
fix(Camera.tsx): processor calling stale worklet and callback

### DIFF
--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -26,7 +26,7 @@ export const Camera = forwardRef(function Camera(
     (data: Barcode[]): void => {
       callback(data);
     },
-    [options]
+    [options, callback]
   );
   const frameProcessor: ReadonlyFrameProcessor = useFrameProcessor(
     (frame: Frame) => {
@@ -35,7 +35,7 @@ export const Camera = forwardRef(function Camera(
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useWorklets(data);
     },
-    []
+    [useWorklets]
   );
   return (
     <>


### PR DESCRIPTION
This fixes a huge bug when depending on state values inside the callback of the frameProcessor. As the frameProcessor had an empty dependency array it always called a stale function identity callback of the worklet which got passed initially.

I.E callback prop calls a function which holds an if clause which depends on a useState value, it has never seen the new useState value if it changed as the new identity/recreated callback function would not be used inside the worklet and frameProcessor.

This fix is important to prevent confusion. I had to debug it for 4 hrs :P